### PR TITLE
Contained sections, sometimes

### DIFF
--- a/resources/public/css/style.scss
+++ b/resources/public/css/style.scss
@@ -256,8 +256,6 @@ button { background-color: transparent;
 
 
 .activity-container {
-  max-width: 100%;
-  width: 35rem;
   .activity-actions {
     background-color: var(--color-hub-primary);
       button {
@@ -344,6 +342,13 @@ button { background-color: transparent;
 .ris-search-result-text { display: inline; }
 
 
+.contain-section-width {
+  max-width: 60rem;
+}
+.center-section {
+  margin: 0 auto;
+}
+
 
 
 
@@ -382,13 +387,6 @@ button { background-color: transparent;
     transform: rotate(360deg);
   }
 }
-
-.activity-container { max-width: 60rem;
-                      margin: 0 auto;
-                      }
-
-
-
 
 .comment {}
 .comment-inner { display: flex;
@@ -451,12 +449,7 @@ button { background-color: transparent;
 
 
 .hub-container {
-  padding: var(--spacing-double);
-  width: 50rem;
-  max-width: calc(min(100vw, 100%));
-  min-width: 50rem;
-  margin: 0 auto;
-
+  width: 66vw;
   .hub-icon {
     @extend .column;
     @extend .p-2;
@@ -475,7 +468,6 @@ button { background-color: transparent;
     // @include big-text;
     @extend .mt-5;
     @extend .mb-5;
-    @extend .br-1;
   }
   
   .stats {

--- a/src/app/kid_game/components/verification_hub/activities/polygon_search.cljs
+++ b/src/app/kid_game/components/verification_hub/activities/polygon_search.cljs
@@ -79,7 +79,7 @@
     (fn []
       [:div.activity-container.image-analysis
        [components/<header> icons/image-analysis "Image Analysis" "Something looks strange here"]
-       [:div.activity-step
+       [:div.activity-step.contain-section-width.center-section
         [:div.activity-description "Mark the parts of the image that look weird to you.  Place pointer, click, and start finsing polygons."]
         [click-image-svg
          image-url

--- a/src/app/kid_game/components/verification_hub/activities/ris_crop.cljs
+++ b/src/app/kid_game/components/verification_hub/activities/ris_crop.cljs
@@ -173,10 +173,10 @@
     (fn []
       [:div.activity-container.ris-simple
        [components/<header> icons/recycle-search "Reverse Image Search" "How cropping images can yield more search results"]
-       [:div.activity-step
+       [:div.activity-step.contain-section-width.center-section
         [<first-drag-step>]]
-       [:div.activity-step
+       [:div.activity-step.contain-section-width.center-section
         [<cropping-step>]]
-       [:div.activity-step
+       [:div.activity-step.contain-section-width.center-section
         [<second-drag-step>]]
        [components/<activity-actions> back!]])))

--- a/src/app/kid_game/components/verification_hub/activities/ris_simple.cljs
+++ b/src/app/kid_game/components/verification_hub/activities/ris_simple.cljs
@@ -43,7 +43,7 @@
        [components/<header> icons/recycle-search "Reverse Image Search" "See where this image might come from"]
        [<header>]
        [image-results/<dragger> main-image drag-done!]
-       [:div.activity-step
+       [:div.activity-step.contain-section-width.center-section
         [css-transition-group {:class "transition-results"}
          (if @loading?
            [image-results/<loading>]

--- a/src/app/kid_game/components/verification_hub/activities/shared/components.cljs
+++ b/src/app/kid_game/components/verification_hub/activities/shared/components.cljs
@@ -11,7 +11,8 @@
     [:p.subtitle subtitle]]])
 
 (defn <activity-actions> [back!]
-  [:div.columns.mt-5.activity-actions.tile.notification.is-success
+  [:div.activity-actions.pb-5.pt-5
+  [:div.columns.mt-5.mb-5.contain-section-width.center-section.has-text-white
    [:div.column.has-text-centered
     [:p "Ready to make a call?"]
     [:button {:class "button is-primary is-inverted is-outlined"
@@ -21,4 +22,4 @@
     [:p "Investigate further?"]
     [:button {:class "button is-primary is-inverted is-outlined"
               :on-click back!}
-     [:span.icon [:i {:class "fas fa-search"}]] [:span "Back to hub"]]]])
+     [:span.icon [:i {:class "fas fa-search"}]] [:span "Back to hub"]]]]])

--- a/src/app/kid_game/components/verification_hub/activities/websearch.cljs
+++ b/src/app/kid_game/components/verification_hub/activities/websearch.cljs
@@ -71,6 +71,7 @@
                            (reset! loading? false)))]
     (fn []
       [:div.activity-container.web-search
+       [:div.activity-step.contain-section-width.center-section
 
        [components/<header> icons/browser-search "Web Search" "Sometimes a basic search is enough"]
        [<blooble-simulation>
@@ -78,5 +79,6 @@
         (if @searched? results nil)
         @loading?
         click!]
+        ]
        [components/<activity-actions> back!]
        ])))

--- a/src/app/kid_game/components/verification_hub/core.cljs
+++ b/src/app/kid_game/components/verification_hub/core.cljs
@@ -18,8 +18,8 @@
                            back! :back!}]
   (let [activities (:activities post)
         activity (find-first (fn [a] (= (:type a) activity-type)) activities)]
-    [:div.columns.is-centered
-     [:div.column.is-8.mt-4
+    [:div.columns
+     [:div.column.is-12.mt-4
       [activities/get-activity activity back!]]]))
 
 (defn <title> [] [:div {:class "columns is-centered mb-5"}
@@ -27,7 +27,7 @@
                    [:h3.title.is-4 "This is Thomas"]
                    [:h5.subtitle "He's your verification compagnon, a kind of personal tutor. Oh, he's also a duck."]]])
 
-(defn <thomas> [] [:div.thomas.columns.is-centered
+(defn <thomas> [] [:div.thomas.columns.is-centered.pt-6
                    [:div.column.is-3
                     [:div.thomas-icon
                      [icons/thomas]]]])
@@ -80,15 +80,17 @@
                   :title "Geolocation"
                   :fn (choose-activity! :geolocation)}]]
     [:div
+     [:div.contain-section-width.center-section
      [<thomas>]
      [<title>]
      [:hr]
-     [<hub-icons> actions]
+     [<hub-icons> actions]]
 
      [:div.scores
+      [:div.contain-section-width.center-section
       [:div {:class "tile is-parent is-vertical"}
        [:h5 {:class "title has-text-white"} "Your score:"]
-       [:p {:class "subtitle has-text-white"} [:b (.toLocaleString points)] " points"]]]
+       [:p {:class "subtitle has-text-white"} [:b (.toLocaleString points)] " points"]]]]
 
      [:div.stats.columns.is-centered
       [:div.stat.column.is-2.has-text-centered


### PR DESCRIPTION
This PR allows things inside the verification hub to be either 100% of
the 66vw, and split themselves down with columns, and also has utility
classes to contain sub-containers to a max width, that can also be
centered.

Cluttered CSS was also removed.

Fixes #95