### PR TITLE
Fixes #83 - design 'refinement'

### DIFF
--- a/resources/public/css/style.scss
+++ b/resources/public/css/style.scss
@@ -79,15 +79,45 @@ body {
     transition: width .4s ease-in-out,
                 box-shadow .4s ease-in-out,
                 filter .4s ease-in-out;
-    filter: // blur(1px)
-            brightness(.8);
     overflow-x: hidden;
-    &.active {
-	box-shadow: 5px 5px 30px 10px rgba(0,0,0,.2);
-	z-index: 1;
-        filter: brightness(1);
+
+    &.game-verification-hub {
+	    box-shadow: 5px 5px 30px 10px rgba(0,0,0,.2);
+	    z-index: 1;
     }
+
+    &.game-timeline {
+      filter: // blur(1px)
+        brightness(.8);
+      &.active {
+        filter: brightness(1);
+      }
+    }
+
 }
+
+.hub-arrow {
+  position: fixed;
+  z-indez: 999;
+  background-color: var(--color-white);
+  width: 6rem;
+  height: 6rem;
+  border-radius: 3rem;
+  margin-left: -2.4rem;
+  top: 6rem;
+  border: 10px solid var(--color-white);
+  cursor: pointer;
+
+  // transitions
+  &.in { left: 33vw; transform:rotate(0deg); }
+  &.out { left: 66vw; transform:rotate(180deg); }
+  transition: left .4s ease-in-out,
+              transform .7s ease-in-out;
+
+  path { fill: var(--color-hub-primary) }
+}
+
+
 
 // .game-panel > * { width: 66vw; }
 

--- a/src/app/kid_game/core.cljs
+++ b/src/app/kid_game/core.cljs
@@ -12,6 +12,7 @@
             [kid-game.components.notifications                    :as notifications]
             [kid-game.components.verification-hub.core            :as <verification-hub>]
             [kid-game.components.verification-hub.activities.core :as activities]
+            [kid-game.components.shared.icons :as icons]
             ;; these NS are imported here for dev hot-reloading.  for some reason it does not work without
             ;; them imported at the top of the tree
             [kid-game.components.verification-hub.activities.websearch]
@@ -24,6 +25,8 @@
   (let [size (if dev?
                {:active "is-half active" :inactive "is-one-quarter is-unselectable"}
                {:active "is-two-thirds active" :inactive "is-one-third is-unselectable"})
+        timeline-active? (= (state/get-panel) :timeline)
+        hub-active? (not timeline-active?)
         pointer-events {:active {:pointer-events "all"} :inactive {:pointer-events "none"}}]
     [:div {:class "game-container columns"}
      [notifications/<notifications>]
@@ -35,11 +38,12 @@
 
      [:div {:class ["game-panel column"
                     "game-timeline"
-                    (cond (= (state/get-panel) :timeline) (:active size)
-                          :else                           (:inactive size))]
+                    (if timeline-active?
+                      (:active size)
+                      (:inactive size))]
             :on-click (fn [ev] (.stopPropagation ev) (state/open-timeline))
             }
-      [:div.click-stopper {:style (if (= (state/get-panel) :timeline)
+      [:div.click-stopper {:style (if timeline-active?
                                     (:active pointer-events)
                                     (:inactive pointer-events))}
        [<timeline>/<container>]]]
@@ -52,7 +56,14 @@
       [:div.click-stopper {:style (if (= (state/get-panel) :verification-hub)
                                     (:active pointer-events)
                                     (:inactive pointer-events))}
-      [<verification-hub>/<container>]]]]))
+       [<verification-hub>/<container>]]]
+
+     [:div.hub-arrow {:class (if timeline-active? "out" "in")
+                      :on-click (fn [] (if timeline-active?
+                                         (state/open-verification-hub)
+                                         (state/open-timeline)))}
+        [icons/circle-right-arrow-blue]]
+     ]))
 
 
 (defn <one-post> [post-id]


### PR DESCRIPTION
Adds an arrow that allows for switching between the panels.  Did this in
pure CSS because it is a one-off interface component with complex
behaviour.

Additionally implemented the panel designs as conceived by the designer:
shadow only ever on timeline, hub always feeling in foreground